### PR TITLE
Postproc borda tests: Añadido tests

### DIFF
--- a/decide/postproc/tests.py
+++ b/decide/postproc/tests.py
@@ -722,7 +722,10 @@ class PostProcTestCase(APITestCase):
                 {'option': 'Option 2', 'number': 2, 'votes': 5},
                 {'option': 'Option 3', 'number': 3, 'votes': 6},
                 {'option': 'Option 4', 'number': 4, 'votes': 8},
-                {'option': 'Option 3', 'number': 3, 'votes': 0},
+                {'option': 'Option 5', 'number': 5, 'votes': 4},
+                {'option': 'Option 6', 'number': 6, 'votes': 6},
+                {'option': 'Option 7', 'number': 7, 'votes': 2},
+                {'option': 'Option 8', 'number': 8, 'votes': 0},
 
             ],
             'order_options': []
@@ -761,7 +764,32 @@ class PostProcTestCase(APITestCase):
         values = response.json()
         self.assertEqual(values, expected_result)
 
+    #Test en el que todos los votos son 0, así viene de votación al no haber ningún
+    #equipo de cabina que pueda realizar votaciones
+    def test_borda_cero_votos(self):
+        data = {
+            'type': 'BORDA',
+            'order_options': [
+                {'option': 'Option 1', 'number': 1, 'order_number': '1', 'votes': 0},
+                {'option': 'Option 2', 'number': 2, 'order_number': '2', 'votes': 0},
+                {'option': 'Option 3', 'number': 3, 'order_number': '3', 'votes': 0},
+                {'option': 'Option 4', 'number': 4, 'order_number': '4', 'votes': 0},
+                {'option': 'Option 5', 'number': 5, 'order_number': '5', 'votes': 0},
+            ]
+        }
 
+        expected_result = [
+            {'option': 'Option 1', 'number': 1, 'order_number': '1', 'votes': 0, 'postproc': 0},
+            {'option': 'Option 2', 'number': 2, 'order_number': '2', 'votes': 0, 'postproc': 0},
+            {'option': 'Option 3', 'number': 3, 'order_number': '3', 'votes': 0, 'postproc': 0},
+            {'option': 'Option 4', 'number': 4, 'order_number': '4', 'votes': 0, 'postproc': 0},
+            {'option': 'Option 5', 'number': 5, 'order_number': '5', 'votes': 0, 'postproc': 0}]
+
+        response = self.client.post('/postproc/', data, format='json')
+        self.assertEqual(response.status_code, 200)
+        values = response.json()
+        print(values)
+        self.assertEqual(values, expected_result)
 
     def test_substrat_1(self):
         seats = 8

--- a/decide/postproc/tests.py
+++ b/decide/postproc/tests.py
@@ -736,6 +736,32 @@ class PostProcTestCase(APITestCase):
         values = response.json()
         self.assertEqual(values, expected_result)
 
+    #Test en el que no se le pasa tipo a una votación de borda
+    def test_borda_no_type(self):
+
+        data = {
+            'order_options': [
+                {'option': 'Option 1', 'number': 1, 'order_number': '1', 'votes': 50},
+                {'option': 'Option 2', 'number': 2, 'order_number': '1', 'votes': 50},
+                {'option': 'Option 3', 'number': 3, 'order_number': '1', 'votes': 0},
+                {'option': 'Option 1', 'number': 1, 'order_number': '2', 'votes': 20},
+                {'option': 'Option 2', 'number': 2, 'order_number': '2', 'votes': 20},
+                {'option': 'Option 3', 'number': 3, 'order_number': '2', 'votes': 60},
+                {'option': 'Option 1', 'number': 1, 'order_number': '3', 'votes': 30},
+                {'option': 'Option 2', 'number': 2, 'order_number': '3', 'votes': 30},
+                {'option': 'Option 3', 'number': 3, 'order_number': '3', 'votes': 40},
+            ]
+        }
+
+        expected_result = {}
+
+        response = self.client.post('/postproc/', data, format='json')
+        self.assertEqual(response.status_code, 400)
+
+        values = response.json()
+        self.assertEqual(values, expected_result)
+
+
 
     def test_substrat_1(self):
         seats = 8


### PR DESCRIPTION
Se han añadido algunos tests para el algoritmo de recuento borda sobre unas situaciones que no se habían contemplado en los demás casos de prueba